### PR TITLE
Put backlog issue in parent story's active sprint

### DIFF
--- a/fc/cli/main.py
+++ b/fc/cli/main.py
@@ -16,15 +16,15 @@ def cli():
 @click.option('--username')
 @click.option('--in-progress', is_flag=True)
 def task(title, description, parent_story, username, in_progress):
-    click.echo('Adding triage task {}; {}'.format(title, description))
+    click.echo('Adding task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)
 
     new_task = Task(title, description, parent_story, in_progress, auth)
     try:
         task_id, url = new_task.create()
-        click.echo('Triage task {} added at {}'.format(task_id, url))
+        click.echo('{} task {} added at {}'.format(new_task.type_str(), task_id, url))
         if in_progress:
             click.echo('Triage task put into In Progress')
     except HTTPError as exception:
-        click.echo('Triage task creation failed with {}'.format(exception))
+        click.echo('{} task creation failed with {}'.format(new_task.type_str(), exception))

--- a/fc/jira/task.py
+++ b/fc/jira/task.py
@@ -38,6 +38,12 @@ class Task:
 
         return self.id, self.url
 
+    def type_str(self) -> str:
+        if self._is_backlog_task():
+            return 'Backlog'
+        else:
+            return 'Triage'
+
     def _create(self):
         ticket_type = 'Triage Task' if self._is_triage_task() else 'Task'
 


### PR DESCRIPTION
- Put backlog issue in parent story's active sprint.
- Tells the user whether the task was a `Triage` or `Backlog`.

Fixes #9.