### PR TITLE
Triage tasks created with importance, effort, and due date

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Helps spread the AwesomeSauce of the Foundational Components team a bit further.
 ## Prerequisites
 [Python 3](https://www.python.org/downloads/) is required.  Python 2 is not supported.
 
-Second, Python 3's `bin` directory needs to be in your `PATH` environment variable.  For example, on macOS, you will
-need to add the following to your `~/.profile`.
+Second, Python 3's `bin` directory needs to be in your `PATH` environment variable.  For example, if you are using the
+python.org install on macOS, you will need to add the following to your `~/.profile`.
 ```bash
 PATH="/Library/Frameworks/Python.framework/Versions/3.*/bin:${PATH}"
 ```
@@ -20,6 +20,13 @@ $ pip3 install fcli
 
 `sudo` may be needed if your Python 3 installation is in a protected directory.  This will put the command the `bin`
 directory of your Python 3 installation.
+
+To update `fcli` to the latest version, run the following.
+```bash
+$ pip3 install --upgrade fcli
+```
+
+Again, `sudo` may be required.
 
 ## Specifying Credentials
 `fcli` uses your EUA credentials to authenticate yourself to JIRA, etc.  There are multiple ways to specify your
@@ -48,16 +55,17 @@ There are two types of task the `fcli` can add: triage tasks and backlog tasks.
 
 To add a triage task,
 ```bash
-$ fcli triage task "<task title>" "<task description>" [--in-progress] [--no-assign]
+$ fcli triage create "<task title>" "<task description>"  [--importance <High/Medium/Low>] [--effort <High/Medium/Low>] [--due <date in the future>] [--in-progress] [--no-assign]
 ```
 
 A new task is created in the triage board with the specified title and description.  Optionally, put the task into the
 In Progress state with the `--in-progress` option, and optionally do not automatically assign the task to yourself with
-`--no-assign`.
+`--no-assign`.  The importance, effort, and due date are required, and they will be prompted for if they are not
+supplied on the command line.
 
 To add a backlog task,
 ```bash
-$ fcli backlog task "<task title>" "<task description>" <parent story>
+$ fcli backlog create "<task title>" "<task description>" <parent story>
 ```
 
 A new task is created in the standard backlog with the specified title and description.  The task is linked with

--- a/fc/cli/backlog.py
+++ b/fc/cli/backlog.py
@@ -1,5 +1,5 @@
 import click
-from ..jira.task import Task
+from ..jira.backlog_task import BacklogTask
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
 
@@ -12,18 +12,16 @@ def backlog():
 @backlog.command()
 @click.argument('title')
 @click.argument('description')
-@click.argument('parent_story', required=True)
+@click.argument('parent_story')
 @click.option('--username')
 def task(title, description, parent_story, username):
-    click.echo('Adding task {}; {}'.format(title, description))
+    click.echo('Adding backlog task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)
 
-    new_task = Task(title, description, parent_story, False, False, auth)
+    new_task = BacklogTask(title, description, parent_story, auth)
     try:
         task_id, url = new_task.create()
-        click.echo('{} task {} added at {}'.format(new_task.type_str(), task_id, url))
-        if in_progress:
-            click.echo('Triage task put into In Progress')
+        click.echo('Backlog task {} added at {}'.format(task_id, url))
     except HTTPError as exception:
-        click.echo('{} task creation failed with {}'.format(new_task.type_str(), exception))
+        click.echo('Backlog task creation failed with {}'.format(exception))

--- a/fc/cli/backlog.py
+++ b/fc/cli/backlog.py
@@ -14,7 +14,7 @@ def backlog():
 @click.argument('description')
 @click.argument('parent_story')
 @click.option('--username')
-def task(title, description, parent_story, username):
+def create(title, description, parent_story, username):
     click.echo('Adding backlog task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)

--- a/fc/cli/main.py
+++ b/fc/cli/main.py
@@ -1,7 +1,4 @@
 import click
-from ..jira.task import Task
-from requests.exceptions import HTTPError
-from ..auth.combo import ComboAuth
 from fc import __version__
 from . import triage
 from . import backlog

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -1,6 +1,6 @@
 import click
 import json
-from ..jira.task import Task
+from ..jira.triage_task import TriageTask
 from ..jira import tasks
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
@@ -22,18 +22,18 @@ def triage():
 @click.option('--loe', prompt='Level of Effort', type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
 @click.option('--due', prompt='Due date (mm/dd/YYYY)', type=click_datetime.Datetime(format='%m/%d/%Y'))
 def create(title, description, username, in_progress, no_assign, importance, loe, due):
-    click.echo('Adding task {}; {}'.format(title, description))
+    click.echo('Adding triage task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)
 
-    new_task = Task(title, description, None, in_progress, no_assign, auth, importance, loe, due)
+    new_task = TriageTask(title, description, in_progress, no_assign, importance, loe, due, auth)
     try:
         task_id, url = new_task.create()
-        click.echo('{} task {} added at {}'.format(new_task.type_str(), task_id, url))
+        click.echo('Triage task {} added at {}'.format(task_id, url))
         if in_progress:
             click.echo('Triage task put into In Progress')
     except HTTPError as exception:
-        click.echo('{} task creation failed with {}'.format(new_task.type_str(), exception))
+        click.echo('Triage task creation failed with {}'.format(exception))
 
 
 @triage.command()

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -45,7 +45,7 @@ def search(username):
 
     try:
         triage_tasks = tasks.triage_search(auth)
-        click.echo('Triage tasks: {}'.format(json.dumps(triage_tasks.json(), indent=4)))
+        click.echo('Triage tasks: {}'.format(json.dumps(triage_tasks, indent=4)))
     except HTTPError as exception:
         click.echo('Task search failed with {}'.format(exception))
 
@@ -59,7 +59,7 @@ def score(username):
 
     try:
         triage_tasks = tasks.triage_search(auth)
-        for task in triage_tasks.json()['issues']:
+        for task in triage_tasks['issues']:
             click.echo('Generating score for task {}'.format(task['key']))
             tasks.score(task, auth)
             click.echo('Triage task VFR updated for {}'.format(task['key']))

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -4,6 +4,7 @@ from ..jira.task import Task
 from ..jira import tasks
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
+import click_datetime
 
 
 @click.group()
@@ -17,12 +18,15 @@ def triage():
 @click.option('--username')
 @click.option('--in-progress', is_flag=True)
 @click.option('--no-assign', is_flag=True)
-def create(title, description, username, in_progress, no_assign):
+@click.option('--importance', prompt=True, type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
+@click.option('--loe', prompt='Level of Effort', type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
+@click.option('--due', prompt='Due date (mm/dd/YYYY)', type=click_datetime.Datetime(format='%m/%d/%Y'))
+def create(title, description, username, in_progress, no_assign, importance, loe, due):
     click.echo('Adding task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)
 
-    new_task = Task(title, description, None, in_progress, no_assign, auth)
+    new_task = Task(title, description, None, in_progress, no_assign, auth, importance, loe, due)
     try:
         task_id, url = new_task.create()
         click.echo('{} task {} added at {}'.format(new_task.type_str(), task_id, url))

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -19,14 +19,14 @@ def triage():
 @click.option('--in-progress', is_flag=True)
 @click.option('--no-assign', is_flag=True)
 @click.option('--importance', prompt=True, type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
-@click.option('--loe', prompt='Level of Effort', type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
-@click.option('--due', prompt='Due date (mm/dd/YYYY)', type=click_datetime.Datetime(format='%m/%d/%Y'))
-def create(title, description, username, in_progress, no_assign, importance, loe, due):
+@click.option('--effort', prompt='Level of Effort', type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
+@click.option('--due', prompt='Due date (mm/dd/yyyy)', type=click_datetime.Datetime(format='%m/%d/%Y'))
+def create(title, description, username, in_progress, no_assign, importance, effort, due):
     click.echo('Adding triage task {}; {}'.format(title, description))
 
     auth = ComboAuth(username)
 
-    new_task = TriageTask(title, description, in_progress, no_assign, importance, loe, due, auth)
+    new_task = TriageTask(title, description, in_progress, no_assign, importance, effort, due, auth)
     try:
         task_id, url = new_task.create()
         click.echo('Triage task {} added at {}'.format(task_id, url))

--- a/fc/jira/backlog_task.py
+++ b/fc/jira/backlog_task.py
@@ -1,0 +1,47 @@
+from .task import Task
+from ..auth.auth import Auth
+
+
+class BacklogTask(Task):
+    def __init__(self, title: str, description: str, parent_story: str, auth: Auth):
+        super(BacklogTask, self).__init__(title, description, auth)
+
+        self.parent_story = parent_story
+
+        self.title = self.parent_story + ': ' + self.title
+
+    def create(self):
+        super(BacklogTask, self).create()
+
+        self._transition(self.transition_id_for_ready_for_refinement)
+        self._transition(self.transition_id_for_refined)
+        self._transition(self.transition_id_for_task_ready)
+
+        return self.id, self.url
+
+    def type_str(self) -> str:
+        return 'Backlog'
+
+    def _extra_json_for_create(self, existing_json: dict):
+        existing_json['fields']['issuetype'] = {
+            'name': 'Task'
+        }
+
+        existing_json['update'] = {
+            'issuelinks': [{
+                'add': {
+                    'type': {
+                        'name': 'Implements',
+                        'inward': 'is implemented by',
+                        'outward': 'implements'
+                    },
+                    'outwardIssue': {
+                        'key': self.parent_story
+                    }
+                }
+            }]
+        }
+
+        parent_story_sprint = self._get_active_sprint_id_of_issue(self.parent_story)
+        if parent_story_sprint is not None:
+            existing_json['fields'][self.issue_assigned_sprint_field] = parent_story_sprint

--- a/fc/jira/task.py
+++ b/fc/jira/task.py
@@ -2,7 +2,6 @@ import requests
 from requests.auth import HTTPBasicAuth
 from ..auth.auth import Auth
 from typing import Optional
-from datetime import datetime
 
 
 class Task:

--- a/fc/jira/task.py
+++ b/fc/jira/task.py
@@ -107,7 +107,7 @@ class Task:
         self.id = response_json['key']
         self.url = self.base_url.format(self.id)
 
-    def _transition(self, id_of_transition):
+    def _transition(self, id_of_transition: str):
         json = {
             'transition': {
                 'id': id_of_transition
@@ -118,14 +118,14 @@ class Task:
                                  auth=HTTPBasicAuth(self.auth.username(), self.auth.password()))
         response.raise_for_status()
 
-    def _get_issue(self, issue_id) -> dict:
+    def _get_issue(self, issue_id: str) -> dict:
         response = requests.get(self.api_url + issue_id,
                                 auth=HTTPBasicAuth(self.auth.username(), self.auth.password()))
         response.raise_for_status()
 
         return response.json()
 
-    def _get_active_sprint_id_of_issue(self, issue_id) -> Optional[int]:
+    def _get_active_sprint_id_of_issue(self, issue_id: str) -> Optional[int]:
         issue = self._get_issue(issue_id)
 
         sprint_list = issue['fields'][self.issue_assigned_sprint_field]

--- a/fc/jira/task.py
+++ b/fc/jira/task.py
@@ -2,6 +2,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 from ..auth.auth import Auth
 from typing import Optional
+from datetime import datetime
 
 
 class Task:
@@ -14,7 +15,8 @@ class Task:
     transition_id_for_task_ready = '221'
     issue_assigned_sprint_field = 'customfield_10005'
 
-    def __init__(self, title: str, description: str, parent_story: str, in_progress: bool, no_assign: bool, auth: Auth):
+    def __init__(self, title: str, description: str, parent_story: Optional[str], in_progress: bool, no_assign: bool,
+                 auth: Auth, importance: str, level_of_importance: str, due_date: datetime):
         self.title = title
         self.description = description
         self.parent_story = parent_story
@@ -23,9 +25,15 @@ class Task:
         self.auth = auth
         self.in_progress = in_progress
         self.no_assign = no_assign
+        self.importance = importance
+        self.level_of_importance = level_of_importance
+        self.due_date = due_date
 
         if self._is_backlog_task():
             self.title = self.parent_story + ': ' + self.title
+
+        if importance is not None and level_of_importance is not None and due_date is not None:
+            self._modify_description_for_parameters(self.importance, self.level_of_importance, self.due_date)
 
     def create(self):
         self._create()
@@ -137,3 +145,8 @@ class Task:
 
     def _is_backlog_task(self) -> bool:
         return not self._is_triage_task()
+
+    def _modify_description_for_parameters(self, importance: str, level_of_importance: str, due_date: datetime):
+        additional_description = 'Importance: {}\r\n\r\nLOE: {}\r\n\r\nDate needed: {}'\
+            .format(importance, level_of_importance, due_date.strftime('%m/%d/%Y'))
+        self.description = self.description + '\r\n\r\n' + additional_description + '\r\n\r\n'

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -2,21 +2,26 @@ import datetime
 import re
 import requests
 from requests.auth import HTTPBasicAuth
-from ..auth.auth import Auth
 from .task import Task
 
 search_url = 'https://jira.cms.gov/rest/api/2/search?jql='
 
 importance_dict = {
     'High': 10,
+    'high': 10,
     'Medium': 5,
-    'Low': 1
+    'medium': 5,
+    'Low': 1,
+    'low': 1
 }
 
 loe_dict = {
     'High': 1,
+    'high': 1,
     'Medium': 5,
-    'Low': 10
+    'medium': 5,
+    'Low': 10,
+    'low': 10
 }
 
 date_dict = {

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -1,0 +1,44 @@
+from .task import Task
+from datetime import datetime
+from ..auth.auth import Auth
+
+
+class TriageTask(Task):
+    def __init__(self, title: str, description: str, in_progress: bool, no_assign: bool, importance: str,
+                 level_of_effort: str, due_date: datetime, auth: Auth):
+        super(TriageTask, self).__init__(title, description, auth)
+
+        self.in_progress = in_progress
+        self.no_assign = no_assign
+        self.importance = importance
+        self.level_of_effort = level_of_effort
+        self.due_date = due_date
+
+        self._modify_description_for_parameters(self.importance, self.level_of_effort, self.due_date)
+
+    def create(self):
+        super(TriageTask, self).create()
+
+        if self.in_progress:
+            self._transition(self.transition_id_for_triage_ready)
+            self._transition(self.transition_id_for_start_progress)
+
+        return self.id, self.url
+
+    def type_str(self) -> str:
+        return 'Triage'
+
+    def _extra_json_for_create(self, existing_json: dict):
+        existing_json['fields']['issuetype'] = {
+            'name': 'Triage Task'
+        }
+
+        if not self.no_assign:
+            existing_json['fields']['assignee'] = {
+                'name': self.auth.username()
+            }
+
+    def _modify_description_for_parameters(self, importance: str, level_of_importance: str, due_date: datetime):
+        additional_description = 'Importance: {}\r\n\r\nLOE: {}\r\n\r\nDate needed: {}'\
+            .format(importance, level_of_importance, due_date.strftime('%m/%d/%Y'))
+        self.description = self.description + '\r\n\r\n' + additional_description + '\r\n\r\n'

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -1,6 +1,7 @@
 from .task import Task
 from datetime import datetime
 from ..auth.auth import Auth
+from . import tasks
 
 
 class TriageTask(Task):
@@ -18,6 +19,8 @@ class TriageTask(Task):
 
     def create(self):
         super(TriageTask, self).create()
+
+        self._update_vfr()
 
         if self.in_progress:
             self._transition(self.transition_id_for_triage_ready)
@@ -42,3 +45,7 @@ class TriageTask(Task):
         additional_description = 'Importance: {}\r\n\r\nLOE: {}\r\n\r\nDate needed: {}'\
             .format(importance, level_of_importance, due_date.strftime('%m/%d/%Y'))
         self.description = self.description + '\r\n\r\n' + additional_description + '\r\n\r\n'
+
+    def _update_vfr(self):
+        issue_json = self._get_issue(self.id)
+        tasks.score(issue_json, self.auth)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         'click',
         'requests',
+        'click-datetime',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Fixes #25.

- Allows the importance, effort, and due date to be specified via CLI or via prompt.
- Updated README.
- Created triage ticket is automatically scored based on input.
- Subclassed the `Task` class with `TriageTask` and `BacklogTask`.