### PR TITLE
Create and score EL tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If the username or password is not specified in some other fashion, the CLI will
 
 #### Task Creation
 
-There are two types of task the `fcli` can add: triage tasks and backlog tasks.
+There are three types of tasks the `fcli` can add: triage, EL, and backlog tasks.
 
 To add a triage task,
 ```bash
@@ -63,6 +63,14 @@ In Progress state with the `--in-progress` option, and optionally do not automat
 `--no-assign`.  The importance, effort, and due date are required, and they will be prompted for if they are not
 supplied on the command line.
 
+To add an EL task,
+```bash
+$ fcli el create "<task title>" "<task description>"  [--importance <High/Medium/Low>] [--effort <High/Medium/Low>] [--due <date in the future>] [--in-progress] [--no-assign]
+```
+
+A new task is created in the EL board with the specified title and description.  EL tasks require the same options as
+triage tasks.  
+
 To add a backlog task,
 ```bash
 $ fcli backlog create "<task title>" "<task description>" <parent story>
@@ -73,9 +81,14 @@ the parent story.  If the parent story is already in an active sprint, the task 
 
 #### Other Task Functions
 
-To move a backlog or triage task from one status to another:
+To move a task from one status to another...
 ```bash
 $ fcli task move <task key> <target status>
+```
+
+To run the triage and EL task scoring process...
+```bash
+$ fcli task score
 ```
 
 #### Triage Task Administration
@@ -88,11 +101,6 @@ $ fcli triage search
 ```
 
 A json representation of all of the open triage tasks will be printed to the terminal.
-
-To run the triage scoring process,
-```bash
-$ fcli triage score
-```
 
 The scores of all open triage tasks will be updated. The terminal will show progress.
 

--- a/fc/cli/backlog.py
+++ b/fc/cli/backlog.py
@@ -2,6 +2,7 @@ import click
 from ..jira.backlog_task import BacklogTask
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
+from . import cli_library
 
 
 @click.group()
@@ -24,4 +25,4 @@ def create(title, description, parent_story, username):
         task_id, url = new_task.create()
         click.echo('Backlog task {} added at {}'.format(task_id, url))
     except HTTPError as exception:
-        click.echo('Backlog task creation failed with {}'.format(exception))
+        cli_library.fail_execution(1, 'Backlog task creation failed with {}'.format(exception))

--- a/fc/cli/cli_library.py
+++ b/fc/cli/cli_library.py
@@ -1,0 +1,27 @@
+import click
+
+
+_progress_bars = {}
+
+
+def echo(text):
+    click.echo(text)
+
+
+def create_progressbar(label, length):
+    progress_bar = click.progressbar(length=length, label=label)
+    _progress_bars[label] = progress_bar
+
+
+def update_progressbar(label, amount):
+    _progress_bars[label].update(amount)
+
+
+def finish_progressbar(label):
+    _progress_bars[label].finish()
+
+
+def fail_execution(return_code: int, error_string: str):
+    exit_exception = click.ClickException(error_string)
+    exit_exception.exit_code = return_code
+    raise exit_exception

--- a/fc/cli/cli_library.py
+++ b/fc/cli/cli_library.py
@@ -19,6 +19,7 @@ def update_progressbar(label, amount):
 
 def finish_progressbar(label):
     _progress_bars[label].finish()
+    click.echo('')
 
 
 def fail_execution(return_code: int, error_string: str):

--- a/fc/cli/el.py
+++ b/fc/cli/el.py
@@ -1,0 +1,36 @@
+import click
+import json
+from ..jira.triage_task import TriageTask
+from ..jira import tasks
+from requests.exceptions import HTTPError
+from ..auth.combo import ComboAuth
+import click_datetime
+
+
+@click.group()
+def el():
+    pass
+
+
+@el.command()
+@click.argument('title')
+@click.argument('description')
+@click.option('--username')
+@click.option('--in-progress', is_flag=True)
+@click.option('--no-assign', is_flag=True)
+@click.option('--importance', prompt=True, type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
+@click.option('--effort', prompt='Level of Effort', type=click.Choice(['Low', 'Medium', 'High'], case_sensitive=False))
+@click.option('--due', prompt='Due date (mm/dd/yyyy)', type=click_datetime.Datetime(format='%m/%d/%Y'))
+def create(title, description, username, in_progress, no_assign, importance, effort, due):
+    click.echo('Adding EL task {}; {}'.format(title, description))
+
+    auth = ComboAuth(username)
+
+    # new_task = TriageTask.from_args(title, description, in_progress, no_assign, importance, effort, due, auth)
+    try:
+        task_id, url = new_task.create()
+        click.echo('EL task {} added at {}'.format(task_id, url))
+        if in_progress:
+            click.echo('EL task put into In Progress')
+    except HTTPError as exception:
+        click.echo('EL task creation failed with {}'.format(exception))

--- a/fc/cli/el.py
+++ b/fc/cli/el.py
@@ -3,6 +3,7 @@ from ..jira.el_task import ElTask
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
 import click_datetime
+from . import cli_library
 
 
 @click.group()
@@ -31,4 +32,4 @@ def create(title, description, username, in_progress, no_assign, importance, eff
         if in_progress:
             click.echo('EL task put into In Progress')
     except HTTPError as exception:
-        click.echo('EL task creation failed with {}'.format(exception))
+        cli_library.fail_execution(1, 'EL task creation failed with {}'.format(exception))

--- a/fc/cli/el.py
+++ b/fc/cli/el.py
@@ -1,7 +1,5 @@
 import click
-import json
-from ..jira.triage_task import TriageTask
-from ..jira import tasks
+from ..jira.el_task import ElTask
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
 import click_datetime
@@ -26,7 +24,7 @@ def create(title, description, username, in_progress, no_assign, importance, eff
 
     auth = ComboAuth(username)
 
-    # new_task = TriageTask.from_args(title, description, in_progress, no_assign, importance, effort, due, auth)
+    new_task = ElTask.from_args(title, description, in_progress, no_assign, importance, effort, due, auth)
     try:
         task_id, url = new_task.create()
         click.echo('EL task {} added at {}'.format(task_id, url))

--- a/fc/cli/main.py
+++ b/fc/cli/main.py
@@ -1,6 +1,7 @@
 import click
 from . import triage
 from . import backlog
+from . import el
 from . import version
 from . import task
 
@@ -12,5 +13,6 @@ def cli():
 
 cli.add_command(triage.triage)
 cli.add_command(backlog.backlog)
+cli.add_command(el.el)
 cli.add_command(version.version)
 cli.add_command(task.task)

--- a/fc/cli/main.py
+++ b/fc/cli/main.py
@@ -1,5 +1,4 @@
 import click
-from fc import __version__
 from . import triage
 from . import backlog
 from . import version

--- a/fc/cli/task.py
+++ b/fc/cli/task.py
@@ -2,6 +2,7 @@ import click
 from ..jira.task import Task
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
+from ..jira import tasks
 
 
 @click.group()
@@ -31,3 +32,20 @@ def move(username: str, task_id: str, state: str):
         click.echo('Successfully transitioned {} to state {}'.format(task_id, state))
     else:
         click.echo('Failed to retrieve a task for key {}'.format(task_id))
+
+
+@task.command()
+@click.option('--username')
+def score(username):
+    click.echo('Scoring triage and EL tasks')
+
+    auth = ComboAuth(username)
+
+    try:
+        triage_and_el_tasks = tasks.triage_and_el_tasks(auth)
+        for current_task in triage_and_el_tasks:
+            click.echo('Generating score for task {}'.format(current_task.id))
+            task_score = task.score()
+            click.echo('Triage task VFR updated with {} for {}'.format(task_score, current_task.id))
+    except HTTPError as exception:
+        click.echo('Task search failed with {}'.format(exception))

--- a/fc/cli/task.py
+++ b/fc/cli/task.py
@@ -1,10 +1,7 @@
 import click
-from ..jira import tasks
+from ..jira.task import Task
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
-
-
-issue_url = 'https://jira.cms.gov/rest/api/2/issue/'
 
 
 @click.group()
@@ -25,8 +22,7 @@ def move(username: str, task_id: str, state: str):
 
     try:
         # use a factory method to GET the issue by key
-        the_task = tasks.get_task(issue_url, task_id, auth)
-
+        the_task = Task.get_task(task_id, auth)
     except HTTPError as exception:
         click.echo('Task search failed with {}'.format(exception))
 

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -44,24 +44,7 @@ def search(username):
     auth = ComboAuth(username)
 
     try:
-        triage_tasks = tasks.triage_search(auth)
-        click.echo('Triage tasks: {}'.format(json.dumps(triage_tasks, indent=4)))
-    except HTTPError as exception:
-        click.echo('Task search failed with {}'.format(exception))
-
-
-@triage.command()
-@click.option('--username')
-def score(username):
-    click.echo('Scoring triage tasks')
-
-    auth = ComboAuth(username)
-
-    try:
-        triage_tasks = tasks.triage_search(auth)
-        for task in triage_tasks:
-            click.echo('Generating score for task {}'.format(task.id))
-            task_score = task.score()
-            click.echo('Triage task VFR updated with {} for {}'.format(task_score, task.id))
+        triage_tasks_raw = tasks.search_for_triage(auth)
+        click.echo('Triage tasks: {}'.format(json.dumps(triage_tasks_raw, indent=4)))
     except HTTPError as exception:
         click.echo('Task search failed with {}'.format(exception))

--- a/fc/cli/triage.py
+++ b/fc/cli/triage.py
@@ -5,6 +5,7 @@ from ..jira import tasks
 from requests.exceptions import HTTPError
 from ..auth.combo import ComboAuth
 import click_datetime
+from . import cli_library
 
 
 @click.group()
@@ -33,7 +34,7 @@ def create(title, description, username, in_progress, no_assign, importance, eff
         if in_progress:
             click.echo('Triage task put into In Progress')
     except HTTPError as exception:
-        click.echo('Triage task creation failed with {}'.format(exception))
+        cli_library.fail_execution(1, 'Triage task creation failed with {}'.format(exception))
 
 
 @triage.command()
@@ -47,4 +48,4 @@ def search(username):
         triage_tasks_raw = tasks.search_for_triage(auth)
         click.echo('Triage tasks: {}'.format(json.dumps(triage_tasks_raw, indent=4)))
     except HTTPError as exception:
-        click.echo('Task search failed with {}'.format(exception))
+        cli_library.fail_execution(1, 'Task search failed with {}'.format(exception))

--- a/fc/jira/backlog_task.py
+++ b/fc/jira/backlog_task.py
@@ -1,6 +1,5 @@
 from .task import Task
 from ..auth.auth import Auth
-from datetime import datetime
 
 
 class BacklogTask(Task):

--- a/fc/jira/el_task.py
+++ b/fc/jira/el_task.py
@@ -1,0 +1,5 @@
+from .triage_task import TriageTask
+
+
+class ElTask(TriageTask):
+    pass

--- a/fc/jira/el_task.py
+++ b/fc/jira/el_task.py
@@ -2,4 +2,10 @@ from .triage_task import TriageTask
 
 
 class ElTask(TriageTask):
-    pass
+    def type_str(self) -> str:
+        return 'EL'
+
+    def _extra_json_for_create(self, existing_json: dict):
+        super(ElTask, self)._extra_json_for_create(existing_json)
+
+        existing_json['fields']['labels'] = ['EL']

--- a/fc/jira/el_task.py
+++ b/fc/jira/el_task.py
@@ -2,6 +2,13 @@ from .triage_task import TriageTask
 
 
 class ElTask(TriageTask):
+    date_to_score = {
+        (0, 11): 20,
+        (12, 21): 15,
+        (22, 42): 10,
+        (43, 63): 5
+    }
+
     def type_str(self) -> str:
         return 'EL'
 

--- a/fc/jira/task.py
+++ b/fc/jira/task.py
@@ -114,9 +114,10 @@ class Task:
         response.raise_for_status()
 
     @classmethod
-    def get_task(cls, issue_id: str, auth: Auth):
+    def get_task(cls, issue_id: str, auth: Auth) -> 'Task':
         from .backlog_task import BacklogTask
         from .triage_task import TriageTask
+        from .el_task import ElTask
 
         issue_json = {}
         task = None
@@ -132,7 +133,11 @@ class Task:
         elif type == 'Task':
             task = BacklogTask.from_json(issue_json, auth)
         else:
-            task = TriageTask.from_json(issue_json, auth)
+            labels: list = issue_json['fields']['labels']
+            if 'EL' in labels:
+                task = ElTask.from_json(issue_json, auth)
+            else:
+                task = TriageTask.from_json(issue_json, auth)
 
         return task
 

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -1,15 +1,13 @@
 import datetime
 import re
 import requests
-from fc.jira.backlog_task import BacklogTask
-from requests import HTTPError
+# from requests import HTTPError
 from requests.auth import HTTPBasicAuth
-
-from fc.exceptions.task_exception import TaskException
-# from .triage_task import TriageTask
-from . import triage_task
+# from fc.exceptions.task_exception import TaskException
+# from . import backlog_task
+# from . import triage_task
 from ..auth.auth import Auth
-from .task import Task
+from . import task
 from typing import Tuple, Optional
 
 
@@ -106,7 +104,7 @@ def _update_triage_vfr(issue: str, score: int, auth: Auth):
 
     # custom field for VFR = customfield_18402
 
-    response = requests.put(Task.api_url + issue, json=json, auth=HTTPBasicAuth(auth.username(), auth.password()))
+    response = requests.put(task.Task.api_url + issue, json=json, auth=HTTPBasicAuth(auth.username(), auth.password()))
     response.raise_for_status()
 
 
@@ -117,32 +115,3 @@ def _get_date_score(num_days: int) -> int:
             return date_dict[key]
 
     return 0
-
-
-def get_issue(api_url: str, issue_id: str, auth: Auth) -> dict:
-    response = requests.get(api_url + issue_id,
-                            auth=HTTPBasicAuth(auth.username(), auth.password()))
-    response.raise_for_status()
-
-    return response.json()
-
-
-def get_task(api_url: str, issue_id: str, auth: Auth) -> Task:
-
-    issue_json = {}
-    task = None
-
-    try:
-        issue_json = get_issue(api_url, issue_id, auth)
-    except HTTPError as exception:
-        raise TaskException('Invalid issue key {}'.format(issue_id)) from exception
-
-    type = issue_json['fields']['issuetype']['name']
-    if type != 'Task' and type != 'Triage Task':
-        raise TaskException('Invalid issue type {}'.format(type))
-    elif type == 'Task':
-        task = BacklogTask.from_json(issue_json, auth)
-    else:
-        task = triage_task.TriageTask.from_json(issue_json, auth)
-
-    return task

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -1,11 +1,7 @@
 import datetime
 import re
 import requests
-# from requests import HTTPError
 from requests.auth import HTTPBasicAuth
-# from fc.exceptions.task_exception import TaskException
-# from . import backlog_task
-# from . import triage_task
 from ..auth.auth import Auth
 from . import task
 from typing import Tuple, Optional

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -13,9 +13,12 @@ search_url = 'https://jira.cms.gov/rest/api/2/search?jql={}'
 def triage_and_el_tasks(auth: Auth) -> List[TriageTask]:
     tasks = []
     raw_tasks = _search_for_triage_and_el(auth)
+    cli_library.create_progressbar('Retrieving Triage and EL tasks', len(raw_tasks['issues']))
     for current_task in raw_tasks['issues']:
-        cli_library.echo('Retrieving info for issue: {}'.format(current_task['key']))
+        cli_library.update_progressbar('Retrieving Triage and EL tasks', 1)
         tasks.append(task.Task.get_task(current_task['key'], auth))
+
+    cli_library.finish_progressbar('Retrieving Triage and EL tasks')
 
     return tasks
 

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -3,26 +3,37 @@ from requests.auth import HTTPBasicAuth
 from ..auth.auth import Auth
 from . import task
 from ..cli import cli_library
+from typing import List
+from .triage_task import TriageTask
 
 
-search_url = 'https://jira.cms.gov/rest/api/2/search?jql='
+search_url = 'https://jira.cms.gov/rest/api/2/search?jql={}'
 
 
-def triage_search(auth: Auth):
-    triage_arr = []
-    triage_issues = _search_for_triage(auth)
-    for issue in triage_issues['issues']:
-        cli_library.echo('Retrieving info for issue: {}'.format(issue['key']))
-        triage_arr.append(task.Task.get_task(issue['key'], auth))
+def triage_and_el_tasks(auth: Auth) -> List[TriageTask]:
+    tasks = []
+    raw_tasks = _search_for_triage_and_el(auth)
+    for current_task in raw_tasks['issues']:
+        cli_library.echo('Retrieving info for issue: {}'.format(current_task['key']))
+        tasks.append(task.Task.get_task(current_task['key'], auth))
 
-    return triage_arr
+    return tasks
 
 
-def _search_for_triage(auth: Auth) -> dict:
+def _search_for_triage_and_el(auth: Auth) -> dict:
+    search_ext = 'project=qppfc+and+issueType="Triage+Task"+and+status+not+in+(resolved,closed)&fields=key,description'
+
+    response = requests.get(search_url.format(search_ext), auth=HTTPBasicAuth(auth.username(), auth.password()))
+    response.raise_for_status()
+
+    return response.json()
+
+
+def search_for_triage(auth: Auth) -> dict:
     search_ext = 'project=qppfc+and+issueType="Triage+Task"+and+(labels is empty or labels+not+in+("EL"))' +\
                  '+and+status+not+in+(resolved,closed)&fields=key,description'
 
-    response = requests.get(search_url + search_ext, auth=HTTPBasicAuth(auth.username(), auth.password()))
+    response = requests.get(search_url.format(search_ext), auth=HTTPBasicAuth(auth.username(), auth.password()))
     response.raise_for_status()
 
     return response.json()

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -2,6 +2,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 from ..auth.auth import Auth
 from . import task
+from ..cli import cli_library
 
 
 search_url = 'https://jira.cms.gov/rest/api/2/search?jql='
@@ -11,7 +12,7 @@ def triage_search(auth: Auth):
     triage_arr = []
     triage_issues = _search_for_triage(auth)
     for issue in triage_issues['issues']:
-        print('Retrieving info for issue: {}'.format(issue['key']))
+        cli_library.echo('Retrieving info for issue: {}'.format(issue['key']))
         triage_arr.append(task.Task.get_task(issue['key'], auth))
 
     return triage_arr

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -46,7 +46,7 @@ class TriageTask(Task):
             'Blocked': [11, 21, 71]}
     }
 
-    importance_dict = {
+    importance_to_score = {
         'High': 10,
         'high': 10,
         'Medium': 5,
@@ -55,7 +55,7 @@ class TriageTask(Task):
         'low': 1
     }
 
-    loe_dict = {
+    loe_to_score = {
         'High': 1,
         'high': 1,
         'Medium': 5,
@@ -64,7 +64,7 @@ class TriageTask(Task):
         'low': 10
     }
 
-    date_dict = {
+    date_to_score = {
         (0, 7): 20,
         (8, 14): 15,
         (15, 28): 10,
@@ -112,12 +112,12 @@ class TriageTask(Task):
         return 'Triage'
 
     def score(self) -> int:
-        (imp_part, loe_part, date_part) = self._find_triage_score_parts()
-        score = self._calc_triage_score(imp_part, loe_part, date_part)
+        (imp_part, loe_part, date_part) = self._find_score_parts()
+        score = self._calculate_score(imp_part, loe_part, date_part)
         self._update_triage_vfr(score)
         return score
 
-    def _find_triage_score_parts(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    def _find_score_parts(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
 
         if self.importance is not None and self.level_of_effort is not None and self.due_date is not None:
             return self.importance, self.level_of_effort, self.due_date
@@ -131,27 +131,45 @@ class TriageTask(Task):
             else:
                 return m.groups()
 
-    def _calc_triage_score(self, imp_part: str, loe_part: str, date_part: str) -> int:
+    def _calculate_score(self, importance: str, level_of_effort: str, due_date: str) -> int:
 
-        dt_score = 0
+        importance_score = self._importance_score(importance)
+        loe_score = self._loe_score(level_of_effort)
+        date_score = self._date_score(due_date)
 
-        imp_score = self.importance_dict.get(imp_part, 0)
+        return importance_score + loe_score + date_score
 
-        loe_score = self.loe_dict.get(loe_part, 0)
+    def _importance_score(self, importance: str) -> int:
+        return self.importance_to_score.get(importance, 0)
 
+    def _loe_score(self, level_of_effort: str) -> int:
+        return self.loe_to_score.get(level_of_effort, 0)
+
+    def _date_score(self, due_date: str) -> int:
         try:
-            dt_obj = datetime.strptime(date_part, '%m/%d/%Y')
+            dt_obj = datetime.strptime(due_date, '%m/%d/%Y')
 
             today = datetime.today()
 
             day_diff = (dt_obj - today).days
 
-            dt_score = self._get_date_score(day_diff)
+            date_score = self._date_score_from_day_delta(day_diff)
 
         except (ValueError, TypeError):
-            dt_score = 0
+            date_score = 0
 
-        return imp_score + loe_score + dt_score
+        return date_score
+
+    def _date_score_from_day_delta(self, days_delta: int) -> int:
+
+        if days_delta < 0:
+            return 20 + (days_delta * -5)
+        else:
+            for key in self.date_to_score:
+                if key[0] <= days_delta <= key[1]:
+                    return self.date_to_score[key]
+
+        return 0
 
     def _update_triage_vfr(self, score: int):
         json = {
@@ -165,17 +183,6 @@ class TriageTask(Task):
         response = requests.put(self.api_url + self.id, json=json,
                                 auth=HTTPBasicAuth(self.auth.username(), self.auth.password()))
         response.raise_for_status()
-
-    def _get_date_score(self, num_days: int) -> int:
-
-        if num_days < 0:
-            return 20 + (num_days * -5)
-        else:
-            for key in self.date_dict:
-                if key[0] <= num_days <= key[1]:
-                    return self.date_dict[key]
-
-        return 0
 
     def _extra_json_for_create(self, existing_json: dict):
         existing_json['fields']['issuetype'] = {

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -1,4 +1,3 @@
-from fc.jira import tasks
 from .task import Task
 from datetime import datetime
 from ..auth.auth import Auth

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -95,7 +95,7 @@ class TriageTask(Task):
         self.description = self.description + '\r\n\r\n' + additional_description + '\r\n\r\n'
 
     def _update_vfr(self):
-        issue_json = tasks.get_issue(self.api_url, self.id, self.auth)
+        issue_json = self._get_issue(self.id, self.auth)
         tasks.score(issue_json, self.auth)
 
     def _get_transition_dict(self) -> dict:


### PR DESCRIPTION
Fixes #46.

- Create EL tasks
- Score EL tasks.  They have a longer period of time at each score level.
- Also refactors more code from `tasks` into the appropriate class.
- Creates a CLI library that can be used to isolate CLI library.