### PR TITLE
Create generic Issue when story or task is outside QPPFC

### DIFF
--- a/fc/jira/backlog_story.py
+++ b/fc/jira/backlog_story.py
@@ -11,20 +11,6 @@ class BacklogStory(BacklogIssue):
         self.duration = None
         self.cost_of_delay = None
 
-    @classmethod
-    def from_json(cls, json: dict, auth: Auth):
-        new_story = cls()
-        super(BacklogStory, new_story).from_json(json, auth)
-
-        return new_story
-
-    @classmethod
-    def from_args(cls, title: str, description: str, auth: Auth):
-        new_story = cls()
-        super(BacklogStory, new_story).from_args(title, description, auth)
-
-        return new_story
-
     def type_str(self) -> str:
         return 'Story'
 

--- a/fc/jira/backlog_task.py
+++ b/fc/jira/backlog_task.py
@@ -6,8 +6,7 @@ class BacklogTask(BacklogIssue):
 
     @classmethod
     def from_json(cls, json: dict, auth: Auth):
-        new_task = cls()
-        super(BacklogTask, new_task).from_json(json, auth)
+        new_task = super(BacklogTask, cls).from_json(json, auth)
 
         issue_links = json['fields']['issuelinks']
 
@@ -20,8 +19,7 @@ class BacklogTask(BacklogIssue):
 
     @classmethod
     def from_args(cls, title: str, description: str, parent_story: str, auth: Auth):
-        new_task = cls()
-        super(BacklogTask, new_task).from_args(title, description, auth)
+        new_task = super(BacklogTask, cls).from_args(title, description, auth)
 
         new_task.parent_story = parent_story
 

--- a/fc/jira/issue.py
+++ b/fc/jira/issue.py
@@ -116,9 +116,12 @@ class Issue:
         except HTTPError as exception:
             raise TaskException('Invalid issue key {}'.format(issue_id)) from exception
 
+        project = issue_json['fields']['project']['key']
         issue_type = issue_json['fields']['issuetype']['name']
-
-        if issue_type == 'Story':
+        if project != 'QPPFC':
+            issue = cls()
+            issue.from_json(issue_json, auth)
+        elif issue_type == 'Story':
             issue = BacklogStory.from_json(issue_json, auth)
         elif issue_type == 'Task':
             issue = BacklogTask.from_json(issue_json, auth)

--- a/fc/jira/issue.py
+++ b/fc/jira/issue.py
@@ -26,24 +26,28 @@ class Issue:
         self.auth = None
         self.project = None
 
-    def from_json(self, json: dict, auth: Auth):
-        self.title = json['fields']['summary']
-        self.description = json['fields']['description']
-        self.id = json['key']
-        self.url = self.base_url.format(json['key'])
-        self.type = json['fields']['issuetype']['name']
-        self.state = json['fields']['status']['name']
-        self.auth = auth
-        self.project = json['fields']['project']['key']
+    @classmethod
+    def from_json(cls, json: dict, auth: Auth):
+        new_issue = cls()
+        new_issue.title = json['fields']['summary']
+        new_issue.description = json['fields']['description']
+        new_issue.id = json['key']
+        new_issue.url = new_issue.base_url.format(json['key'])
+        new_issue.type = json['fields']['issuetype']['name']
+        new_issue.state = json['fields']['status']['name']
+        new_issue.auth = auth
+        new_issue.project = json['fields']['project']['key']
 
-        return self
+        return new_issue
 
-    def from_args(self, title: str, description: str, auth: Auth):
-        self.title = title
-        self.description = description
-        self.auth = auth
+    @classmethod
+    def from_args(cls, title: str, description: str, auth: Auth):
+        new_issue = cls()
+        new_issue.title = title
+        new_issue.description = description
+        new_issue.auth = auth
 
-        return self
+        return new_issue
 
     def create(self):
         json = {
@@ -119,8 +123,7 @@ class Issue:
         project = issue_json['fields']['project']['key']
         issue_type = issue_json['fields']['issuetype']['name']
         if project != 'QPPFC':
-            issue = cls()
-            issue.from_json(issue_json, auth)
+            issue = cls.from_json(issue_json, auth)
         elif issue_type == 'Story':
             issue = BacklogStory.from_json(issue_json, auth)
         elif issue_type == 'Task':
@@ -132,8 +135,7 @@ class Issue:
             else:
                 issue = TriageTask.from_json(issue_json, auth)
         else:
-            issue = cls()
-            issue.from_json(issue_json, auth)
+            issue = cls.from_json(issue_json, auth)
 
         return issue
 

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -75,8 +75,7 @@ class TriageTask(FcIssue):
 
     @classmethod
     def from_json(cls, json: dict, auth: Auth):
-        new_task = cls()
-        super(TriageTask, new_task).from_json(json, auth)
+        new_task = super(TriageTask, cls).from_json(json, auth)
 
         new_task.importance = json['fields'][cls.IMPORTANCE_FIELD]['value']\
             if json['fields'][cls.IMPORTANCE_FIELD] is not None else None
@@ -90,8 +89,7 @@ class TriageTask(FcIssue):
     @classmethod
     def from_args(cls, title: str, description: str, in_progress: bool, assign: bool, importance: str,
                   level_of_effort: str, due_date: datetime, auth: Auth):
-        new_task = cls()
-        super(TriageTask, new_task).from_args(title, description, auth)
+        new_task = super(TriageTask, cls).from_args(title, description, auth)
 
         new_task.in_progress = in_progress
         new_task.assign = assign


### PR DESCRIPTION
Fixes #61.

Before, if a non-FC issue was specified, a FC `BacklogStory` or `BacklogTask` was created.  This would allow the developer to accidentally call methods and other functionality that wouldn't make sense for non-FC issues.  Now just a generic `Issue` is created.