### PR TITLE
Modifies fcli task score:

### DIFF
--- a/fc/cli/backlog.py
+++ b/fc/cli/backlog.py
@@ -77,8 +77,13 @@ def score(issue_id: str, duration: int, cost_of_delay: int, username: str):
         if the_issue.project == 'QPPFC' and the_issue.type_str() == 'Story':
             the_issue.set_duration(duration)
             the_issue.set_cost_of_delay(cost_of_delay)
-            vfr_value = the_issue.score()
-            cli_library.echo('Successfully updated {} with a VFR of {}'.format(issue_id, vfr_value))
+            vfr_value, updated = the_issue.score()
+            if updated:
+                update_str = 'Successfully updated'
+            else:
+                update_str = 'Did not update (same value)'
+
+            cli_library.echo('{} {} with a VFR of {}'.format(update_str, issue_id, vfr_value))
         else:
             err_string = 'Failed to update VFR, issue {} is not a backlog story [{}] or is not the correct project [{}]'
             cli_library.fail_execution(3, err_string.format(issue_id, the_issue.type_str(), the_issue.project))

--- a/fc/jira/fcissue.py
+++ b/fc/jira/fcissue.py
@@ -3,9 +3,31 @@ from requests import HTTPError
 from requests.auth import HTTPBasicAuth
 from ..exceptions.task_exception import TaskException
 from .issue import Issue
+from ..auth.auth import Auth
+from typing import Tuple
 
 
 class FcIssue(Issue):
+
+    score_jira_field = 'customfield_18402'
+
+    def __init__(self):
+        self.score_value = None
+
+    @classmethod
+    def from_json(cls, json: dict, auth: Auth):
+        new_issue = super(FcIssue, cls).from_json(json, auth)
+
+        new_issue.score_value = json[cls.fields_jira_field][cls.score_jira_field]
+
+        return new_issue
+
+    @classmethod
+    def from_args(cls, title: str, description: str, auth: Auth):
+        new_story = super(FcIssue, cls).from_args(title, description, auth)
+
+        return new_story
+
     def transition(self, state: str):
 
         # use created Task (could be Backlog task or Triage task) to transition to desired state
@@ -46,7 +68,7 @@ class FcIssue(Issue):
     def _get_transition_dict(self) -> dict:
         raise NotImplementedError
 
-    def score(self) -> int:
+    def score(self) -> Tuple:
         raise NotImplementedError
 
     def type_str(self) -> str:

--- a/fc/jira/fcissue.py
+++ b/fc/jira/fcissue.py
@@ -22,12 +22,6 @@ class FcIssue(Issue):
 
         return new_issue
 
-    @classmethod
-    def from_args(cls, title: str, description: str, auth: Auth):
-        new_story = super(FcIssue, cls).from_args(title, description, auth)
-
-        return new_story
-
     def transition(self, state: str):
 
         # use created Task (could be Backlog task or Triage task) to transition to desired state

--- a/fc/jira/issue.py
+++ b/fc/jira/issue.py
@@ -23,7 +23,6 @@ class Issue:
     summary_jira_field = 'summary'
     description_jira_field = 'description'
     project_jira_field = 'project'
-    score_jira_field = 'customfield_18402'
 
     def __init__(self):
         self.title = None
@@ -34,7 +33,6 @@ class Issue:
         self.state = None
         self.auth = None
         self.project = None
-        self.score_value = None
 
     @classmethod
     def from_json(cls, json: dict, auth: Auth):
@@ -47,7 +45,6 @@ class Issue:
         new_issue.state = json[cls.fields_jira_field]['status'][cls.name_jira_field]
         new_issue.auth = auth
         new_issue.project = json[cls.fields_jira_field][cls.project_jira_field][cls.key_jira_field]
-        new_issue.score_value = json[cls.fields_jira_field][cls.score_jira_field]
 
         return new_issue
 

--- a/fc/jira/issue.py
+++ b/fc/jira/issue.py
@@ -1,6 +1,8 @@
 import requests
 from requests import HTTPError
 from requests.auth import HTTPBasicAuth
+
+from fc.cli import cli_library
 from ..auth.auth import Auth
 from typing import Optional
 from ..exceptions.task_exception import TaskException
@@ -23,6 +25,7 @@ class Issue:
     summary_jira_field = 'summary'
     description_jira_field = 'description'
     project_jira_field = 'project'
+    score_jira_field = 'customfield_18402'
 
     def __init__(self):
         self.title = None
@@ -33,6 +36,7 @@ class Issue:
         self.state = None
         self.auth = None
         self.project = None
+        self.score_value = None
 
     @classmethod
     def from_json(cls, json: dict, auth: Auth):
@@ -45,6 +49,8 @@ class Issue:
         new_issue.state = json[cls.fields_jira_field]['status'][cls.name_jira_field]
         new_issue.auth = auth
         new_issue.project = json[cls.fields_jira_field][cls.project_jira_field][cls.key_jira_field]
+        new_issue.score_value = json[cls.fields_jira_field][cls.score_jira_field]
+        cli_library.echo('retrieved score field value {}'.format(new_issue.score_value))
 
         return new_issue
 

--- a/fc/jira/issue.py
+++ b/fc/jira/issue.py
@@ -1,8 +1,6 @@
 import requests
 from requests import HTTPError
 from requests.auth import HTTPBasicAuth
-
-from fc.cli import cli_library
 from ..auth.auth import Auth
 from typing import Optional
 from ..exceptions.task_exception import TaskException
@@ -50,7 +48,6 @@ class Issue:
         new_issue.auth = auth
         new_issue.project = json[cls.fields_jira_field][cls.project_jira_field][cls.key_jira_field]
         new_issue.score_value = json[cls.fields_jira_field][cls.score_jira_field]
-        cli_library.echo('retrieved score field value {}'.format(new_issue.score_value))
 
         return new_issue
 

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -33,8 +33,6 @@ def score_triage_and_el_tasks(auth: Auth):
     if len(scoring_results_exception) > 0:
         cli_library.fail_execution(1, 'Task scoring failed')
 
-    scoring_results = [scoring_result for scoring_result in scoring_results if
-                       scoring_result is not None and not isinstance(scoring_result, Exception)]
     cli_library.echo('Tasks: {}, Task scoring results updated: {}'.
                      format(len(raw_tasks['issues']),
                             {i: scoring_results.count(i) for i in scoring_results}))

--- a/fc/jira/tasks.py
+++ b/fc/jira/tasks.py
@@ -33,15 +33,27 @@ def score_triage_and_el_tasks(auth: Auth):
     if len(scoring_results_exception) > 0:
         cli_library.fail_execution(1, 'Task scoring failed')
 
+    scoring_results = [scoring_result for scoring_result in scoring_results if
+                       scoring_result is not None and not isinstance(scoring_result, Exception)]
+    cli_library.echo('Tasks: {}, Task scoring results updated: {}'.
+                     format(len(raw_tasks['issues']),
+                            {i: scoring_results.count(i) for i in scoring_results}))
+
 
 async def _score_triage_and_el_task(task_key: str, auth: Auth):
     loop = asyncio.get_event_loop()
     with ThreadPoolExecutor() as executor:
         cli_library.echo('Retrieving {}'.format(task_key))
         scorable_task = await loop.run_in_executor(executor, issue.Issue.get_issue, task_key, auth)
-        task_score = await loop.run_in_executor(executor, scorable_task.score)
+        task_score, updated = await loop.run_in_executor(executor, scorable_task.score)
+        if updated:
+            update_string = 'updated'
+        else:
+            update_string = 'not updated (same score)'
         cli_library.echo(
-            "{} task's VFR updated with {} for {}".format(scorable_task.type_str(), task_score, scorable_task.id))
+            "{} task's VFR {} with {} for {}".format(scorable_task.type_str(), update_string, task_score,
+                                                     scorable_task.id))
+        return updated
 
 
 def _search_for_triage_and_el(auth: Auth) -> dict:

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -117,7 +117,9 @@ class TriageTask(FcIssue):
 
     def score(self) -> Tuple:
         score = self._calculate_score()
-        self._update_triage_vfr(score) if self.score_value is None or self.score_value != score else None
+
+        if self.score_value is None or self.score_value != score:
+            self._update_triage_vfr(score)
 
         return score, self.score_value != score
 

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -1,3 +1,4 @@
+from fc.cli import cli_library
 from .fcissue import FcIssue
 from datetime import datetime
 from ..auth.auth import Auth
@@ -113,10 +114,12 @@ class TriageTask(FcIssue):
     def type_str(self) -> str:
         return 'Triage'
 
-    def score(self) -> int:
+    def score(self) -> tuple:
         score = self._calculate_score()
-        self._update_triage_vfr(score)
-        return score
+        self._update_triage_vfr(score)\
+            if self.score_value is None or self.score_value != score\
+            else cli_library.echo('not updating score for {} as new score is same'.format(self.id))
+        return score, self.score_value != score
 
     def _calculate_score(self) -> int:
 

--- a/fc/jira/triage_task.py
+++ b/fc/jira/triage_task.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ..auth.auth import Auth
 import requests
 from requests.auth import HTTPBasicAuth
+from typing import Tuple
 
 
 class TriageTask(FcIssue):
@@ -114,11 +115,10 @@ class TriageTask(FcIssue):
     def type_str(self) -> str:
         return 'Triage'
 
-    def score(self) -> tuple:
+    def score(self) -> Tuple:
         score = self._calculate_score()
-        self._update_triage_vfr(score)\
-            if self.score_value is None or self.score_value != score\
-            else cli_library.echo('not updating score for {} as new score is same'.format(self.id))
+        self._update_triage_vfr(score) if self.score_value is None or self.score_value != score else None
+
         return score, self.score_value != score
 
     def _calculate_score(self) -> int:


### PR DESCRIPTION
so that it will only update the score of a triage or EL task if the score has changed, also adds better output to display how many tasks we tried to update and how many tasks were updated vs not updated.

fixes #55 